### PR TITLE
Fix ctor parsing

### DIFF
--- a/sphinxcontrib/dotnetdomain.py
+++ b/sphinxcontrib/dotnetdomain.py
@@ -337,6 +337,11 @@ class DotNetConstructor(DotNetCallable):
     class_object = True
     short_name = 'ctor'
     long_name = 'constructor'
+    signature_pattern = r'''
+        ^(?:(?P<prefix>.+)\.)?
+        (?P<member>\#ctor)
+        (?:\((?P<arguments>[^)]*)\))?$
+    ''' % _re_parts
 
 
 class DotNetProperty(DotNetCallable):

--- a/tests/test_reference_definitions.py
+++ b/tests/test_reference_definitions.py
@@ -50,13 +50,22 @@ class ReferenceDefinitionTests(SphinxTestCase):
 
             .. dn:class:: ClassValid<T>
 
+            .. dn:class:: ClassValid<T><T><T>
+
             .. dn:class:: ClassValid`1
+
+            .. dn:class:: ClassValid`1``0
+
+            .. dn:class:: ClassValid``0
 
             '''
         )
         self.assertRef('ClassValid', 'class')
         self.assertRef('ClassValid<T>', 'class')
+        self.assertRef('ClassValid<T><T><T>', 'class')
         self.assertRef('ClassValid`1', 'class')
+        self.assertRef('ClassValid`1``0', 'class')
+        self.assertRef('ClassValid``0', 'class')
 
     def test_class_invalid(self):
         '''Invalid class parsing'''
@@ -66,7 +75,9 @@ class ReferenceDefinitionTests(SphinxTestCase):
 
             .. dn:class:: ClassParens()
 
-            .. dn:class:: ClassValid`1``0
+            .. dn:class:: ClassValid`0`1
+
+            .. dn:class:: ClassValid`1``1```1
 
             '''
         )
@@ -76,8 +87,10 @@ class ReferenceDefinitionTests(SphinxTestCase):
         assert 'WARNING: Parsing signature failed: "Class NotValid"' in warnings
         self.assertNotRef('ClassParens', 'class')
         assert 'WARNING: Parsing signature failed: "ClassParens()"' in warnings
-        self.assertNotRef('ClassValid`1``0', 'class')
-        assert 'WARNING: Parsing signature failed: "ClassValid`1``0"' in warnings
+        self.assertNotRef('ClassValid`0`1', 'class')
+        assert 'WARNING: Parsing signature failed: "ClassValid`0`1"' in warnings
+        self.assertNotRef('ClassValid`1``1```1', 'class')
+        assert 'WARNING: Parsing signature failed: "ClassValid`1``1```1"' in warnings
 
     def test_class_namespace_nested(self):
         '''Class nested in namespace
@@ -166,8 +179,7 @@ class ReferenceDefinitionTests(SphinxTestCase):
 
             '''
         )
-        # FIXME self.assertRef('ValidClass.MethodNoArgs', 'method')
-
+        self.assertRef('ValidClass.MethodNoArgs', 'method')
         self.assertRef('ValidClass.MethodArg', 'method')
         self.assertRef('ValidClass.MethodArgs', 'method')
         self.assertRef('ValidClass.MethodGeneric', 'method')

--- a/tests/test_reference_definitions.py
+++ b/tests/test_reference_definitions.py
@@ -186,20 +186,20 @@ class ReferenceDefinitionTests(SphinxTestCase):
         self.assertRef('ValidClass.MethodNestedGeneric', 'method')
 
     def test_ctor(self):
-        '''Constructor method'''
+        '''Constructor method parsing'''
         self.app._mock_build(
             '''
             .. dn:class:: ValidClass
 
-                .. dn:constructor:: ValidClass()
+                .. dn:constructor:: #ctor()
 
-                .. dn:constructor:: ValidClass(arg1)
-
-                .. dn:constructor:: ValidClass(arg1,arg2)
+            .. dn:constructor:: UnNested.#ctor()
 
             '''
         )
-        # FIXME self.assertRef('ValidClass#ctor', 'constructor')
+        warnings = self.app._warning.getvalue()
+        self.assertRef('ValidClass.#ctor', 'constructor')
+        self.assertRef('UnNested.#ctor', 'constructor')
 
     def test_callable_constructs(self):
         '''Callable constructs on nested constructs

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -3,57 +3,87 @@
 import unittest
 import time
 
-from sphinxcontrib.dotnetdomain import DotNetSignature
+from sphinxcontrib.dotnetdomain import DotNetCallable, DotNetObjectNested
 
 
 class ParseTests(unittest.TestCase):
 
-    def test_parse_plain(self):
-        '''Parsing vanilla class signatures'''
-        sig = DotNetSignature.from_string('Foo.Bar')
+    def test_parse_nested_plain(self):
+        '''Parsing plain nested object signatures'''
+        sig = DotNetObjectNested.parse_signature('Foo.Bar')
         self.assertEqual(sig.prefix, 'Foo')
         self.assertEqual(sig.member, 'Bar')
         self.assertIsNone(sig.arguments)
 
-        sig = DotNetSignature.from_string('Foo.Bar.test(something)')
+    def test_parse_callable_plain(self):
+        '''Parsing plain callable object signatures'''
+        sig = DotNetCallable.parse_signature('Foo.Bar.test(something)')
         self.assertEqual(sig.prefix, 'Foo.Bar')
         self.assertEqual(sig.member, 'test')
         self.assertIn('something', sig.arguments)
 
-        sig = DotNetSignature.from_string('test(something)')
+        sig = DotNetCallable.parse_signature('test(something)')
         self.assertIsNone(sig.prefix)
         self.assertEqual(sig.member, 'test')
         self.assertIn('something', sig.arguments)
 
     def test_non_matching(self):
         '''Non matching signature should return signature class instance'''
-        self.assertRaises(ValueError, DotNetSignature.from_string,
+        self.assertRaises(ValueError, DotNetCallable.parse_signature,
                           '#this&will%never*parse')
 
     def test_full_name(self):
         '''Full name output'''
-        sig = DotNetSignature.from_string('Foo.Bar')
+        sig = DotNetCallable.parse_signature('Foo.Bar')
         self.assertEqual(sig.full_name(), 'Foo.Bar')
-        sig = DotNetSignature.from_string('Foo.Bar.test(something)')
+        sig = DotNetCallable.parse_signature('Foo.Bar.test(something)')
         self.assertEqual(sig.full_name(), 'Foo.Bar.test')
-        sig = DotNetSignature.from_string('test(something)')
+        sig = DotNetCallable.parse_signature('test(something)')
         self.assertEqual(sig.full_name(), 'test')
 
     def test_generic_type(self):
         '''Generic type declartion in signature'''
-        sig = DotNetSignature.from_string('Foo.Bar`0')
+        sig = DotNetCallable.parse_signature('Foo.Bar`0')
         self.assertEqual(sig.full_name(), 'Foo.Bar`0')
-        sig = DotNetSignature.from_string('Foo.Bar`99')
+        sig = DotNetCallable.parse_signature('Foo.Bar`99')
         self.assertEqual(sig.full_name(), 'Foo.Bar`99')
-        sig = DotNetSignature.from_string('Foo.Bar``0')
+        sig = DotNetCallable.parse_signature('Foo.Bar``0')
         self.assertEqual(sig.full_name(), 'Foo.Bar``0')
-        sig = DotNetSignature.from_string('Foo.Bar<T>')
+        sig = DotNetCallable.parse_signature('Foo.Bar`1``0')
+        self.assertEqual(sig.full_name(), 'Foo.Bar`1``0')
+        sig = DotNetCallable.parse_signature('Foo.Bar<T>')
         self.assertEqual(sig.full_name(), 'Foo.Bar<T>')
+        sig = DotNetCallable.parse_signature('Foo.Bar<T><T>')
+        self.assertEqual(sig.full_name(), 'Foo.Bar<T><T>')
+        sig = DotNetCallable.parse_signature('Foo.Bar<T><T><T>')
+        self.assertEqual(sig.full_name(), 'Foo.Bar<T><T><T>')
+
+    def test_callable_methods(self):
+        '''Callable method parsing'''
+        sig = DotNetCallable.parse_signature('Foo.Bar()')
+        self.assertEqual(sig.full_name(), 'Foo.Bar')
+        sig = DotNetCallable.parse_signature('Foo.Bar(arg1)')
+        self.assertEqual(sig.full_name(), 'Foo.Bar')
+        sig = DotNetCallable.parse_signature('Foo.Bar(arg1, arg2)')
+        self.assertEqual(sig.full_name(), 'Foo.Bar')
+        sig = DotNetCallable.parse_signature('Foo.Bar`1(arg1, arg2)')
+        self.assertEqual(sig.full_name(), 'Foo.Bar`1')
+        sig = DotNetCallable.parse_signature('foobar(arg1, arg2)')
+        self.assertEqual(sig.full_name(), 'foobar')
+
+    def test_invalid_generic_type(self):
+        '''Invalid generic types that shouldn't pass'''
+        self.assertRaises(ValueError, DotNetObjectNested.parse_signature,
+                          'Foo.Bar`0`1')
+        self.assertRaises(ValueError, DotNetObjectNested.parse_signature,
+                          'Foo.Bar<T>`0`1')
+        self.assertRaises(ValueError, DotNetObjectNested.parse_signature,
+                          'Foo.Bar`0`1<T>')
 
     def test_slow_backtrack(self):
         '''Slow query because of excessive backtracking'''
         time_start = time.time()
-        sig = DotNetSignature.from_string('Microsoft.CodeAnalysis.Classification.ClassificationTypeNames.XmlDocCommentAttributeName')
+        sig = DotNetObjectNested.parse_signature('Microsoft.CodeAnalysis.Classification.ClassificationTypeNames.XmlDocCommentAttributeName')
         self.assertEqual(sig.prefix, 'Microsoft.CodeAnalysis.Classification.ClassificationTypeNames')
         self.assertEqual(sig.member, 'XmlDocCommentAttributeName')
         time_end = time.time()

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -3,7 +3,8 @@
 import unittest
 import time
 
-from sphinxcontrib.dotnetdomain import DotNetCallable, DotNetObjectNested
+from sphinxcontrib.dotnetdomain import (DotNetCallable, DotNetObjectNested,
+                                        DotNetConstructor)
 
 
 class ParseTests(unittest.TestCase):
@@ -70,6 +71,18 @@ class ParseTests(unittest.TestCase):
         self.assertEqual(sig.full_name(), 'Foo.Bar`1')
         sig = DotNetCallable.parse_signature('foobar(arg1, arg2)')
         self.assertEqual(sig.full_name(), 'foobar')
+
+    def test_ctor(self):
+        '''Class constructor methods'''
+        sig = DotNetConstructor.parse_signature('Foo.Bar.#ctor')
+        self.assertEqual(sig.full_name(), 'Foo.Bar.#ctor')
+        sig = DotNetConstructor.parse_signature('Foo.Bar.#ctor(arg1)')
+        self.assertEqual(sig.full_name(), 'Foo.Bar.#ctor')
+
+    def test_ctor_invalid(self):
+        '''Invalid class constructor methods'''
+        self.assertRaises(ValueError, DotNetConstructor.parse_signature,
+                          'Foo.Bar#ctor')
 
     def test_invalid_generic_type(self):
         '''Invalid generic types that shouldn't pass'''


### PR DESCRIPTION
This adds basic parsing for #ctor methods.

Depends on #7, fixes #4.