### PR TITLE
This adds the special syntax required for operators, with test cases

### DIFF
--- a/sphinxcontrib/dotnetdomain.py
+++ b/sphinxcontrib/dotnetdomain.py
@@ -384,9 +384,35 @@ class DotNetEvent(DotNetCallable):
 
 
 class DotNetOperator(DotNetCallable):
+    '''Operator object with special parsing
+
+    Parses out signatures that match several cases:
+
+        Prefix.operator ==(args)
+        Prefix.operator true(args)
+        Prefix.operator false(args)
+            This is parsed out with respect to overloadable operators, found at:
+            <https://msdn.microsoft.com/en-us/library/8edha89s.aspx>. We won't
+            list the operators we are searching for here, rather just expect
+            1-3 non-word characters.
+
+        Prefix.implicit operator Prefix.Type(args)
+            Implicit operators specify return type in the declaration, which we
+            don't do anything here but use for the reference. Separate return
+            type is expected as well.
+    '''
+
     class_object = True
     short_name = 'op'
     long_name = 'operator'
+    signature_pattern = r'''
+        ^(?:(?P<prefix>\S+?)\.)?
+        (?P<member>(?:
+            (?:implicit\soperator\s(?:\S+\.)?)?%(name)s |
+            operator\s(?:true|false|\W{1,3})
+        ))
+        (?:\((?P<arguments>[^)]*)\))?$
+    ''' % _re_parts
 
 
 # Cross referencing

--- a/tests/test_reference_definitions.py
+++ b/tests/test_reference_definitions.py
@@ -234,3 +234,22 @@ class ReferenceDefinitionTests(SphinxTestCase):
         self.assertRef('ValidNamespace.NestedClass.NestedClassField', 'field')
         self.assertRef('ValidNamespace.NestedClass.NestedClassEvent', 'event')
         self.assertRef('ValidNamespace.NestedClass.NestedClassOperator', 'operator')
+
+    def test_operator(self):
+        '''Operator references'''
+        self.app._mock_build(
+            '''
+            .. dn:class:: ValidClass
+
+                .. dn:operator:: AnInvalidOperatorWeParseAnyways
+                .. dn:operator:: operator ==(arg1, arg2)
+                .. dn:operator:: operator <=(arg1, arg2)
+                .. dn:operator:: operator true(arg1, arg2)
+                .. dn:operator:: implicit operator Some.Other.Type(arg1)
+            '''
+        )
+        self.assertRef('ValidClass.AnInvalidOperatorWeParseAnyways', 'operator')
+        self.assertRef('ValidClass.operator ==', 'operator')
+        self.assertRef('ValidClass.operator <=', 'operator')
+        self.assertRef('ValidClass.operator true', 'operator')
+        self.assertRef('ValidClass.implicit operator Some.Other.Type', 'operator')


### PR DESCRIPTION
Addresses special operator syntax on UIDs, including:

 * Prefix.operator ==(args)
 * Prefix.operator !=(args)
 * Prefix.operator true(args)

And so on, from overloadable operators at:
https://msdn.microsoft.com/en-us/library/8edha89s.aspx

 * Prefix.implicit operator Prefix.ReturnType(arg)

As well as the invalid, but still parseable for our use case:

 * Prefix.Foo(args)

This closes #12, which is an issue with argument ids, not fullName ids, which
we only have to use in argument lists currently.