### PR TITLE
Update generic regex parsing to include named types

### DIFF
--- a/sphinxcontrib/dotnetdomain.py
+++ b/sphinxcontrib/dotnetdomain.py
@@ -20,7 +20,7 @@ from docutils.parsers.rst import directives
 # Global regex parsing
 _re_parts = {}
 _re_parts['type_dimension'] = r'(?:\`\d+)?(?:\`\`\d+)?'
-_re_parts['type_generic'] = r'(?:\<T[0-9]?\>)+'
+_re_parts['type_generic'] = r'(?:\<(?:T[0-9]?|[^\>]+)\>)+'
 _re_parts['type'] = r'(?:%(type_dimension)s|%(type_generic)s)' % _re_parts
 _re_parts['name'] = r'[\w\_\-]+?%(type)s' % _re_parts
 

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -58,6 +58,10 @@ class ParseTests(unittest.TestCase):
         self.assertEqual(sig.full_name(), 'Foo.Bar<T><T>')
         sig = DotNetCallable.parse_signature('Foo.Bar<T><T><T>')
         self.assertEqual(sig.full_name(), 'Foo.Bar<T><T><T>')
+        sig = DotNetCallable.parse_signature('Foobar<TFoo>')
+        self.assertEqual(sig.full_name(), 'Foobar<TFoo>')
+        sig = DotNetCallable.parse_signature('Foobar<foo>')
+        self.assertEqual(sig.full_name(), 'Foobar<foo>')
 
     def test_callable_methods(self):
         '''Callable method parsing'''


### PR DESCRIPTION
This supports named types, such as `Foo<Bar>`.