### PR TITLE
Allow for both short and long directives and xrefs

### DIFF
--- a/tests/test_reference_definitions.py
+++ b/tests/test_reference_definitions.py
@@ -118,39 +118,38 @@ class ReferenceDefinitionTests(SphinxTestCase):
         '''Nested constructs besides class'''
         self.app._mock_build(
             '''
-            .. dn:structure:: ValidStructure
+            .. dn:struct:: ValidStructure
             .. dn:interface:: ValidInterface
             .. dn:delegate:: ValidDelegate
-            .. dn:enumeration:: ValidEnumeration
+            .. dn:enum:: ValidEnumeration
 
             .. dn:namespace:: ValidNamespace
 
-                .. dn:structure:: NestedStructure
+                .. dn:struct:: NestedStructure
                 .. dn:interface:: NestedInterface
                 .. dn:delegate:: NestedDelegate
-                .. dn:enumeration:: NestedEnumeration
+                .. dn:enum:: NestedEnumeration
 
             .. dn:namespace:: UnNestedNamespace
 
-            .. dn:structure:: UnNestedNamespace.UnNestedStructure
+            .. dn:struct:: UnNestedNamespace.UnNestedStructure
             .. dn:interface:: UnNestedNamespace.UnNestedInterface
             .. dn:delegate:: UnNestedNamespace.UnNestedDelegate
-            .. dn:enumeration:: UnNestedNamespace.UnNestedEnumeration
+            .. dn:enum:: UnNestedNamespace.UnNestedEnumeration
             '''
         )
-        self.assertRef('ValidStructure', 'structure')
-        self.assertRef('ValidNamespace.NestedStructure', 'structure')
-        self.assertRef('UnNestedNamespace.UnNestedStructure', 'structure')
+        self.assertRef('ValidStructure', 'struct')
+        self.assertRef('ValidNamespace.NestedStructure', 'struct')
+        self.assertRef('UnNestedNamespace.UnNestedStructure', 'struct')
         self.assertRef('ValidInterface', 'interface')
         self.assertRef('ValidNamespace.NestedInterface', 'interface')
         self.assertRef('UnNestedNamespace.UnNestedInterface', 'interface')
         self.assertRef('ValidDelegate', 'delegate')
         self.assertRef('ValidNamespace.NestedDelegate', 'delegate')
         self.assertRef('UnNestedNamespace.UnNestedDelegate', 'delegate')
-        self.assertRef('ValidEnumeration', 'enumeration')
-        self.assertRef('ValidNamespace.NestedEnumeration', 'enumeration')
-        self.assertRef('UnNestedNamespace.UnNestedEnumeration', 'enumeration')
-
+        self.assertRef('ValidEnumeration', 'enum')
+        self.assertRef('ValidNamespace.NestedEnumeration', 'enum')
+        self.assertRef('UnNestedNamespace.UnNestedEnumeration', 'enum')
 
     # Test callable members
     def test_method_args(self):

--- a/tests/test_xref.py
+++ b/tests/test_xref.py
@@ -12,24 +12,46 @@ class XRefTests(SphinxTestCase):
             '''
             .. dn:namespace:: ValidNamespace
             .. dn:class:: ValidClass
-            .. dn:structure:: ValidStructure
+            .. dn:struct:: ValidStructure
             .. dn:interface:: ValidInterface
             .. dn:delegate:: ValidDelegate
-            .. dn:enumeration:: ValidEnumeration
+            .. dn:enum:: ValidEnumeration
 
             :dn:ns:`ValidNamespace`
+            :dn:namespace:`ValidNamespace`
             :dn:cls:`ValidClass`
+            :dn:class:`ValidClass`
             :dn:struct:`ValidStructure`
+            :dn:structure:`ValidStructure`
             :dn:iface:`ValidInterface`
+            :dn:interface:`ValidInterface`
             :dn:del:`ValidDelegate`
+            :dn:delegate:`ValidDelegate`
             :dn:enum:`ValidEnumeration`
+            :dn:enumeration:`ValidEnumeration`
             ''')
-        self.assertXRef('ValidNamespace', obj_type='namespace')
-        self.assertXRef('ValidClass', obj_type='class')
-        self.assertXRef('ValidStructure', obj_type='structure')
-        self.assertXRef('ValidInterface', obj_type='interface')
-        self.assertXRef('ValidDelegate', obj_type='delegate')
-        self.assertXRef('ValidEnumeration', obj_type='enumeration')
+        self.assertXRef('ValidNamespace', obj_type='namespace',
+                        obj_ref_type='namespace')
+        self.assertXRef('ValidNamespace', obj_type='namespace',
+                        obj_ref_type='ns')
+        self.assertXRef('ValidClass', obj_type='class', obj_ref_type='class')
+        self.assertXRef('ValidClass', obj_type='class', obj_ref_type='cls')
+        self.assertXRef('ValidStructure', obj_type='struct',
+                        obj_ref_type='struct')
+        self.assertXRef('ValidStructure', obj_type='struct',
+                        obj_ref_type='structure')
+        self.assertXRef('ValidInterface', obj_type='interface',
+                        obj_ref_type='iface')
+        self.assertXRef('ValidInterface', obj_type='interface',
+                        obj_ref_type='interface')
+        self.assertXRef('ValidDelegate', obj_type='delegate',
+                        obj_ref_type='del')
+        self.assertXRef('ValidDelegate', obj_type='delegate',
+                        obj_ref_type='delegate')
+        self.assertXRef('ValidEnumeration', obj_type='enum',
+                        obj_ref_type='enum')
+        self.assertXRef('ValidEnumeration', obj_type='enum',
+                        obj_ref_type='enumeration')
 
     def test_nested_xref(self):
         '''Cross references nested one level deep in a namespace'''
@@ -44,23 +66,23 @@ class XRefTests(SphinxTestCase):
                 * :dn:enum:`NestedEnumeration`
 
                 .. dn:class:: NestedClass
-                .. dn:structure:: NestedStructure
+                .. dn:struct:: NestedStructure
                 .. dn:interface:: NestedInterface
                 .. dn:delegate:: NestedDelegate
-                .. dn:enumeration:: NestedEnumeration
+                .. dn:enum:: NestedEnumeration
             ''')
         self.assertRef('ValidNamespace', 'namespace')
 
         self.assertXRef('NestedClass', prefix='ValidNamespace',
                         obj_type='class')
         self.assertXRef('NestedStructure', prefix='ValidNamespace',
-                        obj_type='structure')
+                        obj_type='struct')
         self.assertXRef('NestedInterface', prefix='ValidNamespace',
                         obj_type='interface')
         self.assertXRef('NestedDelegate', prefix='ValidNamespace',
                         obj_type='delegate')
         self.assertXRef('NestedEnumeration', prefix='ValidNamespace',
-                        obj_type='enumeration')
+                        obj_type='enum')
 
     def test_nested_toplevel_xref(self):
         '''Cross references nested one level deep in a namespace'''
@@ -69,10 +91,10 @@ class XRefTests(SphinxTestCase):
             .. dn:namespace:: ValidNamespace
 
                 .. dn:class:: NestedClass
-                .. dn:structure:: NestedStructure
+                .. dn:struct:: NestedStructure
                 .. dn:interface:: NestedInterface
                 .. dn:delegate:: NestedDelegate
-                .. dn:enumeration:: NestedEnumeration
+                .. dn:enum:: NestedEnumeration
 
             * :dn:cls:`ValidNamespace.NestedClass`
             * :dn:struct:`ValidNamespace.NestedStructure`
@@ -83,10 +105,67 @@ class XRefTests(SphinxTestCase):
         self.assertRef('ValidNamespace', 'namespace')
 
         self.assertXRef('ValidNamespace.NestedClass', obj_type='class')
-        self.assertXRef('ValidNamespace.NestedStructure', obj_type='structure')
+        self.assertXRef('ValidNamespace.NestedStructure', obj_type='struct')
         self.assertXRef('ValidNamespace.NestedInterface', obj_type='interface')
         self.assertXRef('ValidNamespace.NestedDelegate', obj_type='delegate')
-        self.assertXRef('ValidNamespace.NestedEnumeration', obj_type='enumeration')
+        self.assertXRef('ValidNamespace.NestedEnumeration', obj_type='enum')
+
+    def test_xref_long_names(self):
+        '''Long name xref directives'''
+        self.app._mock_build(
+            '''
+            .. dn:namespace:: NamespaceFoo
+            .. dn:struct:: StructFoo
+            .. dn:interface:: InterfaceFoo
+            .. dn:delegate:: DelegateFoo
+            .. dn:enum:: EnumFoo
+            .. dn:class:: ClassFoo
+            .. dn:method:: MethodFoo()
+            .. dn:property:: PropertyFoo()
+            .. dn:operator:: OperatorFoo()
+
+            * :dn:namespace:`NamespaceFoo`
+            * :dn:ns:`NamespaceFoo`
+            * :dn:class:`ClassFoo`
+            * :dn:interface:`InterfaceFoo`
+            * :dn:delegate:`DelegateFoo`
+            * :dn:method:`MethodFoo`
+            * :dn:property:`PropertyFoo`
+            * :dn:operator:`OperatorFoo`
+            ''')
+
+        for (type_short, type_long) in [('ns', 'namespace'),
+                                        ('cls', 'class'),
+                                        ('meth', 'method'),
+                                        ('prop', 'property'),
+                                        ('op', 'operator'),
+                                        ('del', 'delegate'),
+                                        ('iface', 'interface')]:
+            # Lookup for long type exists
+            self.assertXRef(
+                '{0}Foo'.format(type_long.title()),
+                #prefix='ClassFoo',
+                obj_type=type_long,
+                obj_ref_type=type_long
+            )
+            # Lookup for short type doesn't exist yet
+            self.assertNoXRef(
+                '{0}Foo'.format(type_long.title()),
+                #prefix='ClassFoo',
+                obj_type=type_short,
+                obj_ref_type=type_long
+            )
+            # Short name xref = long name xref
+            ret = self.app.env.domains['dn'].find_obj(
+                self.app.env,
+                None,
+                '{0}Foo'.format(type_long.title()),
+                type_short)
+            self.assertEqual(
+                ret,
+                ((type_short, '{0}Foo'.format(type_long.title())),
+                 ('index', type_long))
+            )
 
     def test_class_member_xref(self):
         '''Class member cross references'''

--- a/tests/util.py
+++ b/tests/util.py
@@ -129,8 +129,8 @@ class SphinxTestCase(unittest.TestCase):
         else:
             AssertionError('Reference match found')
 
-    def assertXRef(self, name, prefix=None, obj_type=None, doc='index',
-                   ret_name=None):
+    def assertXRef(self, name, prefix=None, obj_type=None, obj_ref_type=None,
+                   doc='index', ret_name=None):
         '''Assert mocked find_obj was called correctly
 
         Test that inline references generate the correct calls and return to
@@ -148,7 +148,10 @@ class SphinxTestCase(unittest.TestCase):
         # Get class short name for reference first
         self.assertIn(obj_type, self.app.env.domains['dn'].directives,
                       'Missing reference type: %s' % obj_type)
-        obj_ref_type = self.app.env.domains['dn'].directives[obj_type].short_name
+        if obj_ref_type is None:
+            obj_ref_type = (self.app.env.domains['dn']
+                            .directives[obj_type]
+                            .short_name)
         # Assert called correctly and return exists
         args = (self.app.env, prefix, name, obj_ref_type, 0)
         self.mocked_find_obj.assert_has_calls(calls=[(args, {})])


### PR DESCRIPTION
Both short and long directives will create an identical object. Xrefs can then
be either short or long -- they will both resolve to the same object, regardless
of whether the directive was short or long.