### PR TITLE
Adds some option parsing to constructs and property/fields

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
+   syntax
 
 Indices and tables
 ==================

--- a/docs/syntax.rst
+++ b/docs/syntax.rst
@@ -1,7 +1,61 @@
+==================
 .NET Domain Syntax
 ==================
 
 Below are the supported syntax rules to the .NET domain:
+
+General Rules
+=============
+
+Options
+-------
+
+All constructs support the following directive option modifiers:
+
+* public
+* protected
+* static
+
+For example::
+
+    .. dn:class:: Foobar
+        :protected:
+        :static:
+
+These options will prefix the output declaration with a modifier, such as::
+
+    class protected static Foobar
+
+These output modifiers are not part of the object name, and so are not part of
+any cross references.
+
+Properties
+==========
+
+Properties can be defined with the modifier flags:
+
+* getter
+* setter
+
+For example::
+
+    .. dn:property:: Foobar()
+        :setter:
+        :getter:
+
+Fields
+======
+
+Fields can be defined with the modifier flags:
+
+* adder
+* remover
+
+For example::
+
+    .. dn:field:: Foobar()
+        :adder:
+        :remover:
 
 Generic Types
 =============
@@ -13,5 +67,3 @@ Generic type supported syntax::
     .. dn:class:: Foobar<TFoo,TBar>
     .. dn:class:: Foobar<T,<string>>
     .. dn:class:: Foobar<T,<T,<string>>>
-
-

--- a/sphinxcontrib/dotnetdomain.py
+++ b/sphinxcontrib/dotnetdomain.py
@@ -93,6 +93,13 @@ class DotNetObject(ObjectDescription):
     long_name = None
     signature_pattern = None
 
+    option_spec = dict(
+        item for obj in [ObjectDescription.option_spec,
+                         {'public': directives.flag,
+                          'protected': directives.flag,
+                          'static': directives.flag}]
+        for item in obj.items())
+
     @classmethod
     def parse_signature(cls, signature):
         '''Parse signature declartion string
@@ -160,9 +167,14 @@ class DotNetObject(ObjectDescription):
         signode['prefix'] = sig.prefix
         signode['fullname'] = sig.full_name()
 
+        # Prefix modifiers
         if self.display_prefix:
             signode += addnodes.desc_annotation(self.display_prefix,
                                                 self.display_prefix)
+        for prefix in ['public', 'protected', 'static']:
+            if prefix in self.options:
+                signode += addnodes.desc_annotation(prefix + ' ',
+                                                    prefix + ' ')
 
         # Show prefix only on shorter declarations
         if sig.prefix is not None and not self.has_arguments:
@@ -233,10 +245,10 @@ class DotNetObjectNested(DotNetObject):
 
     '''Nestable object'''
 
-    option_spec = {
-        'noindex': directives.flag,
-        'hidden': directives.flag,
-    }
+    option_spec = dict(
+        item for obj in [DotNetObject.option_spec,
+                         {'hidden': directives.flag}]
+        for item in obj.items())
 
     signature_pattern = r'''
         ^(?:(?P<prefix>.+)\.)?

--- a/sphinxcontrib/dotnetdomain.py
+++ b/sphinxcontrib/dotnetdomain.py
@@ -384,6 +384,21 @@ class DotNetConstructor(DotNetCallable):
 
 
 class DotNetProperty(DotNetCallable):
+    '''Property object definition
+
+    Properties can be defined with the following options:
+
+        getter
+            Property has a getter
+
+        setter
+            Property has a setter
+
+    For example::
+
+        .. dn:property:: Example()
+            :getter:
+    '''
     class_object = True
     short_name = 'prop'
     long_name = 'property'
@@ -396,6 +411,22 @@ class DotNetProperty(DotNetCallable):
 
 
 class DotNetField(DotNetCallable):
+    '''Field object definition
+
+    Fields can be defined with the following options:
+
+        adder
+            Field adder
+
+        remover
+            Field remover
+
+    For example::
+
+        .. dn:field:: Example
+            :adder:
+            :remover:
+    '''
     class_object = True
     short_name = 'field'
     long_name = 'field'

--- a/sphinxcontrib/dotnetdomain.py
+++ b/sphinxcontrib/dotnetdomain.py
@@ -388,11 +388,23 @@ class DotNetProperty(DotNetCallable):
     short_name = 'prop'
     long_name = 'property'
 
+    option_spec = dict(
+        item for obj in [DotNetCallable.option_spec,
+                         {'getter': directives.flag,
+                          'setter': directives.flag}]
+        for item in obj.items())
+
 
 class DotNetField(DotNetCallable):
     class_object = True
     short_name = 'field'
     long_name = 'field'
+
+    option_spec = dict(
+        item for obj in [DotNetCallable.option_spec,
+                         {'adder': directives.flag,
+                          'remover': directives.flag}]
+        for item in obj.items())
 
 
 class DotNetEvent(DotNetCallable):

--- a/tests/test_reference_definitions.py
+++ b/tests/test_reference_definitions.py
@@ -283,3 +283,41 @@ class ReferenceDefinitionTests(SphinxTestCase):
                       self.app.builder.output['index'])
         self.assertIn('unknown option: "nope".',
                       self.app._warning.getvalue())
+
+    def test_property_options(self):
+        '''Property directive options'''
+        self.app._mock_build(
+            '''
+            .. dn:property:: GetProperty
+                :getter:
+
+            .. dn:property:: SetProperty
+                :setter:
+
+            .. dn:property:: Property
+                :getter:
+                :setter:
+            '''
+        )
+        self.assertRef('GetProperty', 'property')
+        self.assertRef('SetProperty', 'property')
+        self.assertRef('Property', 'property')
+
+    def test_field_options(self):
+        '''Field directive options'''
+        self.app._mock_build(
+            '''
+            .. dn:field:: AdderField
+                :adder:
+
+            .. dn:field:: RemoverField
+                :remover:
+
+            .. dn:field:: Field
+                :adder:
+                :remover:
+            '''
+        )
+        self.assertRef('AdderField', 'field')
+        self.assertRef('RemoverField', 'field')
+        self.assertRef('Field', 'field')

--- a/tests/test_reference_definitions.py
+++ b/tests/test_reference_definitions.py
@@ -257,3 +257,29 @@ class ReferenceDefinitionTests(SphinxTestCase):
         self.assertRef('ValidClass.operator <=', 'operator')
         self.assertRef('ValidClass.operator true', 'operator')
         self.assertRef('ValidClass.implicit operator Some.Other.Type', 'operator')
+
+    def test_construct_options(self):
+        '''Construct directive options'''
+        self.app._mock_build(
+            '''
+            .. dn:class:: PublicClass
+                :public:
+
+            .. dn:class:: ProtectedClass
+                :protected:
+
+            .. dn:class:: StaticClass
+                :static:
+
+            .. dn:class:: NopeClass
+                :nope:
+            '''
+        )
+        self.assertIn('public PublicClass',
+                      self.app.builder.output['index'])
+        self.assertIn('protected ProtectedClass',
+                      self.app.builder.output['index'])
+        self.assertIn('static StaticClass',
+                      self.app.builder.output['index'])
+        self.assertIn('unknown option: "nope".',
+                      self.app._warning.getvalue())


### PR DESCRIPTION
Adds some options as discussed as part of #25. This adds public, protected, and
static modifiers to constructs, which will show in display.  Property and field
options currently do not yet affect display.