### PR TITLE
Fix parsing errors on ctor definitions

### DIFF
--- a/sphinxcontrib/dotnetdomain.py
+++ b/sphinxcontrib/dotnetdomain.py
@@ -379,7 +379,7 @@ class DotNetConstructor(DotNetCallable):
     long_name = 'constructor'
     signature_pattern = r'''
         ^(?:(?P<prefix>.+)\.)?
-        (?P<member>\#ctor)
+        (?P<member>(?:\#ctor|%(name)s))
         (?:\((?P<arguments>[^)]*)\))?$
     ''' % _re_parts
 

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -84,8 +84,10 @@ class ParseTests(unittest.TestCase):
         '''Class constructor methods'''
         sig = DotNetConstructor.parse_signature('Foo.Bar.#ctor')
         self.assertEqual(sig.full_name(), 'Foo.Bar.#ctor')
-        sig = DotNetConstructor.parse_signature('Foo.Bar.#ctor(arg1)')
+        sig = DotNetConstructor.parse_signature('Foo.Bar.#ctor(T1)')
         self.assertEqual(sig.full_name(), 'Foo.Bar.#ctor')
+        sig = DotNetConstructor.parse_signature('Foo.Bar.Something(T1)')
+        self.assertEqual(sig.full_name(), 'Foo.Bar.Something')
 
     def test_ctor_invalid(self):
         '''Invalid class constructor methods'''


### PR DESCRIPTION
Adds support for syntax that doesn't match `Foo.Bar.#ctor`