### PR TITLE
Add parsing for Foo{Bar{Baz}} style generics

### DIFF
--- a/sphinxcontrib/dotnetdomain.py
+++ b/sphinxcontrib/dotnetdomain.py
@@ -22,12 +22,12 @@ from docutils.parsers.rst import directives
 _re_parts = {}
 _re_parts['type_dimension'] = r'(?:\`\d+)?(?:\`\`\d+)?'
 _re_parts['type_generic'] = r'''
-    (?:\<
-        (?:[\w]+|\<.+?\>)
+    (?:[\<\{]
+        (?:[\w]+|[\<\{].+?[\>\}])
         (?:,\s?
-            (?:[\w]+|\<.+?\>)
+            (?:[\w]+|[\<\{].+?[\>\}])
         )*?
-    \>)(?!\<[^\>]+\>)
+    [\>\}])(?![\<\{][^\>\}]+[\>\}])
 '''
 _re_parts['type'] = r'(?:%(type_dimension)s|%(type_generic)s)' % _re_parts
 _re_parts['name'] = r'[\w\_\-]+?%(type)s' % _re_parts

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -106,8 +106,18 @@ class ParseTests(unittest.TestCase):
     @unittest.expectedFailure
     def test_generic_braces(self):
         '''Unknown generic syntax parsing with braces'''
-        sig = DotNetCallable.parse_signature('Foo.Bar{`1}')
+        sig = DotNetCallable.parse_signature('Foo.Bar{`1}()')
         self.assertEqual(sig.full_name(), 'Foo.Bar{`1}')
+
+    def test_alternate_generic(self):
+        '''Unknown brace syntax common in references'''
+        sig = DotNetCallable.parse_signature(
+            'System.Linq.Expressions.Expression'
+            '{System.Func{{TUser},System.Boolean}}')
+        self.assertEqual(
+            sig.full_name(),
+            ('System.Linq.Expressions.Expression'
+             '{System.Func{{TUser},System.Boolean}}'))
 
     def test_operator(self):
         '''Operator signature parsing'''


### PR DESCRIPTION
Not sure exactly what this syntax is, it is common in reference links in api
output and related to #11.