### PR TITLE
Drop code style operator syntax for op_Name syntax

### DIFF
--- a/sphinxcontrib/dotnetdomain.py
+++ b/sphinxcontrib/dotnetdomain.py
@@ -447,35 +447,9 @@ class DotNetEvent(DotNetCallable):
 
 class DotNetOperator(DotNetCallable):
 
-    '''Operator object with special parsing
-
-    Parses out signatures that match several cases:
-
-        Prefix.operator ==(args)
-        Prefix.operator true(args)
-        Prefix.operator false(args)
-            This is parsed out with respect to overloadable operators, found at:
-            <https://msdn.microsoft.com/en-us/library/8edha89s.aspx>. We won't
-            list the operators we are searching for here, rather just expect
-            1-3 non-word characters.
-
-        Prefix.implicit operator Prefix.Type(args)
-            Implicit operators specify return type in the declaration, which we
-            don't do anything here but use for the reference. Separate return
-            type is expected as well.
-    '''
-
     class_object = True
     short_name = 'op'
     long_name = 'operator'
-    signature_pattern = r'''
-        ^(?:(?P<prefix>\S+?)\.)?
-        (?P<member>(?:
-            (?:implicit\soperator\s(?:\S+\.)?)?%(name)s |
-            operator\s(?:true|false|\W{1,3})
-        ))
-        (?:\((?P<arguments>[^)]*)\))?$
-    ''' % _re_parts
 
 
 # Cross referencing

--- a/tests/test_reference_definitions.py
+++ b/tests/test_reference_definitions.py
@@ -242,17 +242,17 @@ class ReferenceDefinitionTests(SphinxTestCase):
             .. dn:class:: ValidClass
 
                 .. dn:operator:: AnInvalidOperatorWeParseAnyways
-                .. dn:operator:: operator ==(T1, T2)
-                .. dn:operator:: operator <=(T1, T2)
-                .. dn:operator:: operator true(T1, T2)
-                .. dn:operator:: implicit operator Some.Other.Type(T1)
+                .. dn:operator:: op_Equal(T1, T2)
+                .. dn:operator:: op_LessThanOrEqual(T1, T2)
+                .. dn:operator:: op_True(T1, T2)
+                .. dn:operator:: op_implicit(T1)
             '''
         )
         self.assertRef('ValidClass.AnInvalidOperatorWeParseAnyways', 'operator')
-        self.assertRef('ValidClass.operator ==', 'operator')
-        self.assertRef('ValidClass.operator <=', 'operator')
-        self.assertRef('ValidClass.operator true', 'operator')
-        self.assertRef('ValidClass.implicit operator Some.Other.Type', 'operator')
+        self.assertRef('ValidClass.op_Equal', 'operator')
+        self.assertRef('ValidClass.op_LessThanOrEqual', 'operator')
+        self.assertRef('ValidClass.op_True', 'operator')
+        self.assertRef('ValidClass.op_implicit', 'operator')
 
     def test_construct_options(self):
         '''Construct directive options'''

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -112,29 +112,25 @@ class ParseTests(unittest.TestCase):
     def test_operator(self):
         '''Operator signature parsing'''
         # Implicit operator
-        sig = DotNetOperator.parse_signature('Foo.implicit operator Bar(arg)')
+        sig = DotNetOperator.parse_signature('Foo.op_implicit(arg)')
         self.assertEqual(sig.prefix, 'Foo')
-        self.assertEqual(sig.member, 'implicit operator Bar')
-        raw = ('Microsoft.CodeAnalysis.Options.Option<T>.implicit operator '
-               'Microsoft.CodeAnalysis.Options.OptionKey'
+        self.assertEqual(sig.member, 'op_implicit')
+        raw = ('Microsoft.CodeAnalysis.Options.Option<T>.op_implicit'
                '(Microsoft.CodeAnalysis.Options.Option<T>)')
         sig = DotNetOperator.parse_signature(raw)
         self.assertEqual(sig.prefix,
                          'Microsoft.CodeAnalysis.Options.Option<T>')
-        self.assertEqual(sig.member,
-                         ('implicit operator '
-                          'Microsoft.CodeAnalysis.Options.OptionKey'))
-        self.assertEqual(sig.full_name(),
-                         ('Microsoft.CodeAnalysis.Options.Option<T>'
-                          '.implicit operator '
-                          'Microsoft.CodeAnalysis.Options.OptionKey'))
+        self.assertEqual(sig.member, 'op_implicit')
         # Other operators
-        sig = DotNetOperator.parse_signature('Foo.operator <=(arg)')
-        self.assertEqual(sig.member, 'operator <=')
-        sig = DotNetOperator.parse_signature('Foo.operator true(arg)')
-        self.assertEqual(sig.member, 'operator true')
-        sig = DotNetOperator.parse_signature('Foo.operator false(arg)')
-        self.assertEqual(sig.member, 'operator false')
+        sig = DotNetOperator.parse_signature('Foo.op_LessThanOrEqual(T1)')
+        self.assertEqual(sig.member, 'op_LessThanOrEqual')
+        sig = DotNetOperator.parse_signature('Foo.op_True(T1)')
+        self.assertEqual(sig.member, 'op_True')
+        sig = DotNetOperator.parse_signature('Foo.op_False(T1)')
+        self.assertEqual(sig.member, 'op_False')
+        # Some old/no longer valid or used declarations
+        self.assertRaises(ValueError, DotNetOperator.parse_signature,
+                          'Foo.operator ==(args)')
         self.assertRaises(ValueError, DotNetOperator.parse_signature,
                           'Foo.operator foo(args)')
         self.assertRaises(ValueError, DotNetOperator.parse_signature,
@@ -143,13 +139,6 @@ class ParseTests(unittest.TestCase):
                           'Foo.operator ==foo(args)')
         self.assertRaises(ValueError, DotNetOperator.parse_signature,
                           'Foo.operator <==>(args)')
-
-        raw = ('Microsoft.CodeAnalysis.ProjectId.operator '
-               '==(Microsoft.CodeAnalysis.ProjectId, '
-               'Microsoft.CodeAnalysis.ProjectId)')
-        sig = DotNetOperator.parse_signature(raw)
-        self.assertEqual(sig.full_name(),
-                         'Microsoft.CodeAnalysis.ProjectId.operator ==')
 
     def test_slow_backtrack(self):
         '''Slow query because of excessive backtracking'''


### PR DESCRIPTION
This drops support for declarations like:

    Foo.operator ==(T1, T2)

and instead expects:

    Foo.op_Equal(T1, T2)

Fixes #31 