### PR TITLE
Incompatible py3 code

### DIFF
--- a/sphinxcontrib/dotnetdomain.py
+++ b/sphinxcontrib/dotnetdomain.py
@@ -507,7 +507,7 @@ class DotNetIndex(Index):
 
     def generate(self, doc_names=None):
         content = {}
-        objects = sorted(self.domain.data['objects'].iteritems(),
+        objects = sorted(self.domain.data['objects'].items(),
                          key=lambda x: x[1][0].lower())
         for (obj_type, obj_name), (obj_doc_name, _) in objects:
             if doc_names and obj_doc_name not in doc_names:
@@ -535,7 +535,7 @@ class DotNetIndex(Index):
             ])
 
         # sort by first letter
-        content = sorted(content.iteritems())
+        content = sorted(content.items())
         return content, False
 
 
@@ -633,7 +633,7 @@ class DotNetDomain(Domain):
             return None
 
     def get_objects(self):
-        for (obj_type, obj_name), (obj_doc, obj_doc_type) in self.data['objects'].iteritems():
+        for (obj_type, obj_name), (obj_doc, obj_doc_type) in self.data['objects'].items():
             obj_short_type = self.directives[obj_doc_type].short_name
             yield obj_name, obj_name, obj_short_type, obj_doc, obj_name, 1
 


### PR DESCRIPTION
```
Exception occurred:
  File "/Users/anthony/.pyenv/versions/sphinx34/lib/python3.4/site-packages/sphinxcontrib/dotnetdomain.py", line 510, in generate
    objects = sorted(self.domain.data['objects'].iteritems(),
AttributeError: 'dict' object has no attribute 'iteritems'
The full traceback has been saved in /var/folders/0z/3wz65d6s1dvcrqnhxqd1kvjr0000gn/T/sphinx-err-fvx0wshw.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
make: *** [html] Error 1
```