### PR TITLE
Fix a number of linking issues

### DIFF
--- a/prospector.yml
+++ b/prospector.yml
@@ -7,9 +7,9 @@ ignore-paths:
   - docs
 
 pep8:
-    full: true
-    options:
-        max-line-length: 100
+  full: true
+  options:
+    max-line-length: 100
 
 pylint:
   max-line-length: 100
@@ -19,3 +19,5 @@ mccabe:
 
 pep257:
   run: false
+  disable:
+    - D211

--- a/tests/test_xref.py
+++ b/tests/test_xref.py
@@ -1,6 +1,6 @@
 import unittest
 
-from util import SphinxTestCase
+from util import SphinxTestCase, MockTestXMLBuilder
 
 
 class XRefTests(SphinxTestCase):
@@ -416,3 +416,27 @@ class XRefTests(SphinxTestCase):
         self.assertXRef('GoofyClass<T>', obj_type='class')
         self.assertXRef('GoofyClass<T,T>', obj_type='class')
         self.assertXRef('GoofyClass<T,T,T>', obj_type='class')
+
+    def test_basic_xref(self):
+        '''Basic cross references, not nested'''
+        self.app.builder = MockTestXMLBuilder(self.app)
+        self.app._mock_build(
+            '''
+            .. dn:namespace:: ValidNamespace
+
+                .. dn:class:: ValidClass
+
+                    Test comment
+
+            :dn:class:`~ValidNamespace.ValidClass`
+            ''')
+        self.assertXRef('ValidNamespace.ValidClass', obj_type='class',
+                        obj_ref_type='class')
+        self.assertIn(
+            ('<reference internal="True" '
+             'refid="ValidNamespace.ValidClass" '
+             'reftitle="ValidNamespace.ValidClass">'
+             '<literal classes="xref dn dn-class">ValidClass</literal>'
+             '</reference>'),
+            self.app.builder.output['index'],
+        )

--- a/tests/test_xref.py
+++ b/tests/test_xref.py
@@ -163,7 +163,7 @@ class XRefTests(SphinxTestCase):
                 type_short)
             self.assertEqual(
                 ret,
-                ((type_short, '{0}Foo'.format(type_long.title())),
+                ('{0}Foo'.format(type_long.title()),
                  ('index', type_long))
             )
 
@@ -265,7 +265,9 @@ class XRefTests(SphinxTestCase):
     def test_xref_collision_type_difference(self):
         '''Cross reference but with type differences
 
-        On differing types, colliding names should both be addressable.
+        On a type that is defined more than once, the last defined object will
+        be the one that is found by object searches. The whole group will be
+        targetted by reference links however
         '''
         self.app._mock_build(
             '''
@@ -279,8 +281,6 @@ class XRefTests(SphinxTestCase):
                 .. dn:field:: Nested()
                 .. dn:property:: Nested()
             ''')
-        self.assertXRef('Nested', prefix='ValidClass', obj_type='method')
-        self.assertXRef('Nested', prefix='ValidClass', obj_type='field')
         self.assertXRef('Nested', prefix='ValidClass', obj_type='property')
 
     def test_xref_collision_multiple_namespaces(self):

--- a/tests/util.py
+++ b/tests/util.py
@@ -141,7 +141,7 @@ class SphinxTestCase(unittest.TestCase):
         obj_ref_type = self.app.env.domains['dn'].directives[obj_type].short_name
         try:
             objects = self.app.env.domaindata[domain]['objects']
-            (obj_doc_name, _) = objects[obj_ref_type, obj_name]
+            (obj_doc_name, _) = objects[obj_name]
             self.assertEqual(
                 doc_name, obj_doc_name,
                 'Reference docname mismatch: expected {0}, actual {1}'
@@ -196,7 +196,7 @@ class SphinxTestCase(unittest.TestCase):
             ret_name = name
             if prefix is not None:
                 ret_name = '.'.join([prefix, name])
-        ((_, found_name), found_meta) = found
+        (found_name, found_meta) = found
         self.assertIsNotNone(found_name,
                              'XRef {0} not found'.format(ret_name))
         (found_doc, found_type) = found_meta


### PR DESCRIPTION
This addresses a number of linking issues, and includes a light refactor of how
we are building up the domain data.


This drops the need for accumulating a special dictionary using the format:

```
(object type, object name) -> (object full name, object role type)
```

This was originally written this way to combine roles like `class` and `cls`
into a single lookup. Instead, this improves on the role mapping and doesn't
explicitly state the object type. The domain object mapping now uses the common
format of:

```
object_name -> (object full name, object role type)
```

The only deficiency of this is that when multiple objects have the same name,
but different types, the first object will be the one to receive reference
links. This shouldn't be an issue for most use cases however.


* Objects are mapped in a standard way
* A global role `obj` was added, to allow `any` style references
* New fields were created to reference this object type, for automatic linking.
  This piece required the `obj` role above, and is the basis for refactoring
  the object storage
* References now support `~`
* The generated index output was repaired
* Additional object lookup mechanisms were added, for backing down to a wider
  search breadth

Fixes #48
Fixes #52