### PR TITLE
Add nested parameter linking

### DIFF
--- a/sphinxcontrib/dotnetdomain.py
+++ b/sphinxcontrib/dotnetdomain.py
@@ -38,7 +38,7 @@ _re_parts['name'] = r'[\w\_\-]+?%(type)s' % _re_parts
 
 class DotNetSignature(object):
 
-    """Signature parsing for .NET directives
+    """Signature parsing for .NET dieectives
 
     Attributes
         prefix
@@ -325,21 +325,68 @@ class DotNetXRefMixin(object):
 
     """Add .NET handling for `.` and `~` reference operators"""
 
-    def make_xref(self, rolename, domain, target, innernode=nodes.emphasis,
-                  contnode=None):
-        result = super(DotNetXRefMixin, self).make_xref(
-            rolename, domain, target, innernode, contnode)
-        result['refspecific'] = True
-        if target.startswith(('.', '~')):
-            prefix, result['reftarget'] = target[0], target[1:]
-            if prefix == '.':
-                text = target[1:]
-            elif prefix == '~':
-                text = target.split('.')[-1]
-            for node in result.traverse(nodes.Text):
-                node.parent[node.parent.index(node)] = nodes.Text(text)
+    nested_pattern = re.compile(r'^(?P<parent>[^{]+?)\{(?P<inner>.+)\}$')
+    alias_pattern = re.compile(r'^(?P<target>[^{]+?)\<(?P<alias>.+)\>$')
+
+    def split_refs(self, target):
+
+        def alias_target(ref):
+            found = self.alias_pattern.match(ref)
+            if found:
+                return (found.group('target'), found.group('alias'))
+            return (ref, None)
+
+        refs = []
+        current = target
+        while True:
+            found = self.nested_pattern.match(current)
+            if not found:
+                refs.append(alias_target(current))
                 break
-        return result
+            current = found.group('inner')
+            refs.append(alias_target(found.group('parent')))
+        return refs
+
+    def make_xref(self, rolename, domain, target_name, innernode=nodes.emphasis,
+                  contnode=None):
+        if not rolename:
+            return contnode or innernode(target_name, target_name)
+
+        field_node = None
+        refs = self.split_refs(target_name)
+        refs.reverse()
+        for (target_name, target_alias) in refs:
+            if not target_alias and target_name.startswith(('.', '~')):
+                prefix, target_name = target_name[0], target_name[1:]
+                if prefix == '.':
+                    target_alias = target_name[1:]
+                elif prefix == '~':
+                    target_alias = target_name.split('.')[-1]
+            if target_alias is None:
+                target_alias = target_name
+            ref_node = addnodes.pending_xref(
+                '',
+                refdomain=domain,
+                refexplicit=False,
+                reftype=rolename,
+                reftarget=target_alias,
+                refspecific=True,
+            )
+            ref_node += nodes.Text(target_name, target_name)
+            if field_node is None:
+                field_node = nodes.inline()
+                field_node += ref_node
+            else:
+                inner_node = field_node
+                field_node = nodes.inline()
+                field_node += [
+                    ref_node,
+                    nodes.Text('<', '<'),
+                    inner_node,
+                    nodes.Text('>', '>'),
+                ]
+
+        return innernode('', '', field_node)
 
 
 class DotNetBasicField(DotNetXRefMixin, Field):
@@ -522,11 +569,12 @@ class DotNetXRefRole(AnyXRefRole):
 
         This method also resolves special reference operators ``~`` and ``.``
         """
-        super(DotNetXRefRole, self).process_link(env, refnode,
-                                                 has_explicit_title, title,
-                                                 target)
+        result = super(DotNetXRefRole, self).process_link(env, refnode,
+                                                          has_explicit_title,
+                                                          title, target)
+        (title, target) = result
         if not has_explicit_title:
-            # If the first character is a tilde, don't display the prefix
+            # If the first character is a tilde, don't display the parent name
             title = title.lstrip('.')
             target = target.lstrip('~')
             if title[0:1] == '~':

--- a/sphinxcontrib/dotnetdomain.py
+++ b/sphinxcontrib/dotnetdomain.py
@@ -38,7 +38,7 @@ _re_parts['name'] = r'[\w\_\-]+?%(type)s' % _re_parts
 
 class DotNetSignature(object):
 
-    """Signature parsing for .NET dieectives
+    """Signature parsing for .NET directives
 
     Attributes
         prefix

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,0 +1,31 @@
+import unittest
+
+from sphinxcontrib.dotnetdomain import DotNetXRefMixin
+
+
+class FieldTests(unittest.TestCase):
+
+    """Test for xref fields"""
+
+    def test_split(self):
+        cls = DotNetXRefMixin()
+        self.assertEqual(
+            cls.split_refs('TFoo'),
+            [('TFoo', None)]
+        )
+        self.assertEqual(
+            cls.split_refs('Foo<Foo`1>'),
+            [('Foo', 'Foo`1')]
+        )
+        self.assertEqual(
+            cls.split_refs('Foo<Foo`1>{Bar<Bar`1>}'),
+            [('Foo', 'Foo`1'), ('Bar', 'Bar`1')]
+        )
+        self.assertEqual(
+            cls.split_refs('Foo`1<Foo>{Bar`1<Bar>}'),
+            [('Foo`1', 'Foo'), ('Bar`1', 'Bar')]
+        )
+        self.assertEqual(
+            cls.split_refs('Foo`1<Foo>{Bar`1<Bar>{TFoo}}'),
+            [('Foo`1', 'Foo'), ('Bar`1', 'Bar'), ('TFoo', None)]
+        )


### PR DESCRIPTION
This adds nested parameter linking to parameter and return types. This uses a
special output format from the autoapi output to link reference types.

Refs rtfd/sphinx-autoapi#66