### PR TITLE
Adds support for .NET indexers

### DIFF
--- a/sphinxcontrib/dotnetdomain.py
+++ b/sphinxcontrib/dotnetdomain.py
@@ -23,17 +23,25 @@ from docutils import nodes
 
 # Global regex parsing
 _re_parts = {}
-_re_parts['type_dimension'] = r'(?:\`\d+)?(?:\`\`\d+)?'
-_re_parts['type_generic'] = r'''
-    (?:[\<\{]
-        (?:[\w]+|[\<\{].+?[\>\}])
-        (?:,\s?
-            (?:[\w]+|[\<\{].+?[\>\}])
-        )*?
-    [\>\}])(?![\<\{][^\>\}]+[\>\}])
+_re_parts['type_dimension'] = r'''
+    (?:\`\d+)?      # non-greedy search for dimension syntax: `1
+    (?:\`\`\d+)?    # non-greedy search for dimension syntax: ``1
 '''
+_re_parts['type_generic'] = r'''
+    (?:[\<\{]                           # open bracket for generic
+        (?:[\w]+|[\<\{].+?[\>\}])       # first parameter type, word or generic
+        (?:,\s?                         # group of next parameters
+            (?:[\w]+|[\<\{].+?[\>\}])   # parameter type, word or generic
+        )*?                             # non-greedy search for unlimited groups
+    [\>\}])                             # close bracket for generic
+    (?![\<\{][^\>\}]+[\>\}])
+'''
+# Parameter types should be either a dimension or generic syntax
 _re_parts['type'] = r'(?:%(type_dimension)s|%(type_generic)s)' % _re_parts
+# Indexer type syntax is slightly different than generic, parse separately for a
+# normal type declaration in an indexer declaration
 _re_parts['type_indexer'] = r'(\[[\w\_\-\.]+?%(type)s\])?' % _re_parts
+# Look for either the type declaration or and indexer declaration
 _re_parts['name'] = r'[\w\_\-]+?(?:%(type)s|%(type_indexer)s)' % _re_parts
 
 

--- a/sphinxcontrib/dotnetdomain.py
+++ b/sphinxcontrib/dotnetdomain.py
@@ -33,7 +33,8 @@ _re_parts['type_generic'] = r'''
     [\>\}])(?![\<\{][^\>\}]+[\>\}])
 '''
 _re_parts['type'] = r'(?:%(type_dimension)s|%(type_generic)s)' % _re_parts
-_re_parts['name'] = r'[\w\_\-]+?%(type)s' % _re_parts
+_re_parts['type_indexer'] = r'(\[[\w\_\-\.]+?%(type)s\])?' % _re_parts
+_re_parts['name'] = r'[\w\_\-]+?(?:%(type)s|%(type_indexer)s)' % _re_parts
 
 
 class DotNetSignature(object):

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -158,3 +158,9 @@ class ParseTests(unittest.TestCase):
         self.assertEqual(sig.member, 'XmlDocCommentAttributeName')
         time_end = time.time()
         self.assertTrue((time_end - time_start) < 2)
+
+    def test_indexers(self):
+        """Indexer types"""
+        sig = DotNetCallable.parse_signature('ClassLibrary3.TagHelperAttributeList.Item[System.String]')
+        self.assertEqual(sig.prefix, 'ClassLibrary3.TagHelperAttributeList')
+        self.assertEqual(sig.member, 'Item[System.String]')

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,9 @@ commands =
     py.test {posargs}
 
 [testenv:docs]
+deps =
+    Sphinx>=1.4
+    sphinx_rtd_theme
 changedir = {toxinidir}/docs
 commands =
     sphinx-build -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html


### PR DESCRIPTION
This assumes the contstruct name can be in one of the following formats:

```
foo[System.string] (indexer)
foo`1
foo{System.string}
```