### PR TITLE
Add support for sphinx 1.4 latex writer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: python
 python:
   - 2.7
+  - 3.5
 sudo: true
 env:
-  - TOX_ENV=py27
-  - TOX_ENV=py34
+  - TOX_ENV=py27-sphinx13
+  - TOX_ENV=py27-sphinx14
+  - TOX_ENV=py35-sphinx13
+  - TOX_ENV=py35-sphinx14
   - TOX_ENV=lint
   - TOX_ENV=docs
 install:
@@ -14,6 +17,6 @@ script:
 notifications:
   slack:
     rooms:
-      - readthedocs:y3hjODOi7EIz1JAbD1Zb41sz#general
+      - readthedocs:y3hjODOi7EIz1JAbD1Zb41sz#random
     on_success: change
     on_failure: always

--- a/sphinxcontrib/dotnetdomain.py
+++ b/sphinxcontrib/dotnetdomain.py
@@ -8,7 +8,7 @@ from itertools import chain
 
 from six import iteritems
 
-from sphinx import addnodes
+from sphinx import addnodes, version_info as sphinx_version_info
 from sphinx.domains import Domain, ObjType, Index
 from sphinx.locale import l_
 from sphinx.directives import ObjectDescription
@@ -20,6 +20,8 @@ from sphinx.util.docfields import Field, TypedField
 from docutils.parsers.rst import directives
 from docutils import nodes
 
+
+SPHINX_VERSION_14 = (sphinx_version_info >= (1, 4))
 
 # Global regex parsing
 _re_parts = {}
@@ -228,8 +230,10 @@ class DotNetObject(ObjectDescription):
 
         index_text = self.get_index_text(None, name_obj)
         if index_text:
-            self.indexnode['entries'].append(('single', index_text, full_name,
-                                              ''))
+            entry = ('single', index_text, full_name, '')
+            if SPHINX_VERSION_14:
+                entry = ('single', index_text, full_name, '', None)
+            self.indexnode['entries'].append(entry)
 
     def get_index_text(self, prefix, name_obj):
         """Produce index text by directive attributes"""

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,32 @@
 [tox]
-envlist = py27,py34,lint,docs
+envlist = py{27,35}-sphinx{13,14},lint,docs
 
 [testenv]
+basepython =
+    py27: python2.7
+    py35: python3.5
+    lint: python2.7
+    docs: python2.7
 setenv =
     LANG=C
 deps =
     pytest
     mock
+    sphinx13: Sphinx>=1.3.5
+    sphinx14: Sphinx>=1.4
 commands =
     py.test {posargs}
 
 [testenv:docs]
+deps =
+    Sphinx>=1.4
+    sphinx_rtd_theme
 changedir = {toxinidir}/docs
 commands =
     sphinx-build -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html
 
 [testenv:lint]
 deps =
-    {[testenv]deps}
     prospector
 commands =
     prospector \


### PR DESCRIPTION
Adds support for multiple formats of entry listing for the latex writer.  I'm
not sure if there is an easy way to mock out the latex builder, it seems to be
more complicated than the others. I added support for multiple sphinx version
tests anyways.

Fixes #56