### PR TITLE
Remove arguments from property display

### DIFF
--- a/sphinxcontrib/dotnetdomain.py
+++ b/sphinxcontrib/dotnetdomain.py
@@ -509,6 +509,7 @@ class DotNetProperty(DotNetCallable):
     class_object = True
     short_name = 'prop'
     long_name = 'property'
+    has_arguments = False
 
     option_spec = dict(
         item for obj in [DotNetCallable.option_spec,

--- a/tests/test_reference_definitions.py
+++ b/tests/test_reference_definitions.py
@@ -298,6 +298,8 @@ class ReferenceDefinitionTests(SphinxTestCase):
         self.assertRef('GetProperty', 'property')
         self.assertRef('SetProperty', 'property')
         self.assertRef('Property', 'property')
+        self.assertNotIn('Property()', self.app.builder.output['index'])
+        self.assertIn('Property', self.app.builder.output['index'])
 
     def test_field_options(self):
         '''Field directive options'''


### PR DESCRIPTION
Properties should not have callable arguments

Fixes #50 