### PR TITLE
Deprecate project

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,12 @@
 Sphinx .Net Domain
 ==================
 
+.. image:: http://unmaintained.tech/badge.svg
+  :target: http://unmaintained.tech
+  :alt: No Maintenance Intended
+
+----
+
 .. image:: https://readthedocs.org/projects/sphinxcontrib-dotnetdomain/badge/?version=latest
    :target: https://sphinxcontrib-dotnetdomain.readthedocs.org
    :alt: Documentation Status


### PR DESCRIPTION
Hello everyone, we would like to communicate that we are effectively deprecating sphinxcontrib-dotnetdomain. Unfortunately, we haven't been maintaining the package for a long time, and it is now incompatible with newer versions of Sphinx (3.x and 4.x, see https://github.com/readthedocs/sphinxcontrib-dotnetdomain/pull/68).

I am leaving this pull request open for a few days in case folks want to chime in and express their views, and in principle, we will merge it and archive the repository before the Christmas holidays.